### PR TITLE
fix: Usa rutas relativas en local, VITE_API_URL solo en Render

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,3 @@
-VITE_API_URL=https://capygaming-backend.onrender.com
+# Variables de entorno para producción
+# En Docker local: Sin VITE_API_URL para usar rutas relativas /api (nginx hace proxy)
+# En Render: Configurar VITE_API_URL como variable de entorno en el dashboard


### PR DESCRIPTION
ConfigurE el proyecto para funcionar tanto en Docker local como en Render, solucionando errores de nginx y CORS.

Problema

- En Render: nginx fallaba con `host not found in upstream 'backend'`
- En local: Frontend llamaba a URLs de producción causando errores CORS

Solución

Configuración dual de nginx

- `nginx.conf`**: Con proxy para Docker local (`backend:3001`)
- `nginx.prod.conf`**: Sin proxy para Render (llamadas directas a API)
- `Dockerfile`**: Elige qué nginx usar según `ARG NGINX_CONF`